### PR TITLE
Fix some installation issues

### DIFF
--- a/lib/helpers/setup_composer.sh
+++ b/lib/helpers/setup_composer.sh
@@ -3,9 +3,9 @@
 composer_check_signature() {
 	EXPECTED_SIGNATURE=$(wget -O - https://composer.github.io/installer.sig)
         wget -O composer-setup.php https://getcomposer.org/installer
-	ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+	echo "$EXPECTED_SIGNATURE composer-setup.php" | sha384sum -c -
 
-	if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+	if [ "$?" != "0" ]
 	then
 			rm composer-setup.php
 			die 'ERROR: Invalid installer signature'

--- a/lib/helpers/setup_composer.sh
+++ b/lib/helpers/setup_composer.sh
@@ -1,7 +1,7 @@
 # require utils/messages.sh
 # require utils/errors.sh
 composer_check_signature() {
-	EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
+	EXPECTED_SIGNATURE=$(wget -O - https://composer.github.io/installer.sig)
 	php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 	ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
 

--- a/lib/helpers/setup_composer.sh
+++ b/lib/helpers/setup_composer.sh
@@ -2,7 +2,7 @@
 # require utils/errors.sh
 composer_check_signature() {
 	EXPECTED_SIGNATURE=$(wget -O - https://composer.github.io/installer.sig)
-	php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+        wget -O composer-setup.php https://getcomposer.org/installer
 	ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
 
 	if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]


### PR DESCRIPTION
I encountered some issues while using this script:

- It seams like php copy() does not handle http(s)_proxy environment variables correctly. I was not able to establish a connection with php while curl/wget/whatever worked fine.
- Solution: Replace the php copy() call with wget as wget was used before

- Replaced the sha384 checksumming using php by just making use of sha384sum

After those changes the script run without any errors.